### PR TITLE
Enable PDF build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -63,6 +63,5 @@
     "Pdf": {
       "template_folder": "_themes.pdf"
     }
-  },
-  "need_generate_pdf": false
+  }
 }


### PR DESCRIPTION
# Openbare bijdragen worden op dit moment niet geaccepteerd

Deze opslagplaats is openbaar gemaakt om het downloaden en gebruiken van deze inhoud te vergemakkelijken zodat aangepaste Help-oplossingen kunnen worden gecreëerd.
We accepteren op dit moment geen openbare bijdragen aan deze opslagplaats of deze inhoud.
Als u wilt bijdragen aan de door Microsoft gepubliceerde inhoud, gaat u naar de opslagplaats voor de Engelse versie waar openbare bijdragen worden verwerkt.
